### PR TITLE
使新mpy支持携带lv_binding编译，升级lvgl9

### DIFF
--- a/m5stack/CMakeLists.txt
+++ b/m5stack/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SDKCONFIG_DEFAULTS ${CMAKE_BINARY_DIR}/sdkconfig.combined)
 if(BUILD_WITH_LVGL)
     # Include LVGL component, ignore KCONFIG
     idf_build_set_property(LV_MICROPYTHON 1)
+    include_directories(${CMAKE_SOURCE_DIR}/components/lv_bindings)
     idf_build_component(${CMAKE_SOURCE_DIR}/components/lv_bindings/lvgl)
     idf_build_set_property(COMPILE_DEFINITIONS "-DLV_KCONFIG_IGNORE" APPEND)
     separate_arguments(LV_CFLAGS_ENV UNIX_COMMAND $ENV{LV_CFLAGS})

--- a/m5stack/Makefile
+++ b/m5stack/Makefile
@@ -97,7 +97,7 @@ define pack_fw
 		$(BUILD)/uiflow-Sx-$(GIT_VERSION).uf2
 endef
 
-.PHONY: all build deploy flash flash_all clean erase nvs fs pack pack_all littlefs mpy-cross submodules FORCE
+.PHONY: all fix_lv_bindings build deploy flash flash_all clean erase nvs fs pack pack_all littlefs mpy-cross submodules FORCE
 
 all: nvs fs pack
 	@echo ""
@@ -105,8 +105,14 @@ all: nvs fs pack
 
 $(BUILD)/bootloader/bootloader.bin $(BUILD)/partition_table/partition-table.bin $(BUILD)/micropython.bin: FORCE
 
+# Change lv_bindings
+# fix lv_bindings path bug as lv_micropython sub project 
+fix_lv_bindings:
+	sed -i 's|lib/lv_bindings/include/|include/|g' components/lv_bindings/lv_conf.h
+	sed -i 's|MP_OBJ_TO_PTR(self_in);|(mp_ptr_t*)(MP_OBJ_TO_PTR(self_in));|g' components/lv_bindings/driver/include/common.h
+
 # Build the MicroPython firmware.
-build: nvs
+build: nvs fix_lv_bindings
 	idf.py $(IDFPY_FLAGS) build
 
 # Deploy the MicroPython.

--- a/m5stack/cmodules/m5unified/m5unified.h
+++ b/m5stack/cmodules/m5unified/m5unified.h
@@ -2,7 +2,7 @@
 
 #if MICROPY_PY_LVGL
 #include "lvgl/lvgl.h"
-#include "lvgl/src/hal/lv_hal_disp.h"
+#include "lvgl/src/hal/lv_hal.h"
 #include "./../../components/lv_bindings/driver/include/common.h"
 #endif
 

--- a/m5stack/cmodules/m5unified/m5unified_gfx.c
+++ b/m5stack/cmodules/m5unified/m5unified_gfx.c
@@ -12,7 +12,7 @@ extern mp_obj_t user_panel_make_new(const mp_obj_type_t *type, size_t n_args, si
 #if MICROPY_PY_LVGL
 extern void gfx_lvgl_flush(void *_disp_drv, const lv_area_t *area, lv_color_t *color_p);
 extern void user_lvgl_flush(void *_disp_drv, const lv_area_t *area, lv_color_t *color_p);
-extern bool gfx_lvgl_touch_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data);
+extern bool gfx_lvgl_touch_read(lv_indev_t *indev_drv, lv_indev_data_t *data);
 DEFINE_PTR_OBJ(gfx_lvgl_flush);
 DEFINE_PTR_OBJ(user_lvgl_flush);
 DEFINE_PTR_OBJ(gfx_lvgl_touch_read);

--- a/m5stack/components/M5Unified/mpy_lvgl.txt
+++ b/m5stack/components/M5Unified/mpy_lvgl.txt
@@ -1,9 +1,9 @@
 #if MICROPY_PY_LVGL
 #include "lvgl/lvgl.h"
-#include "lvgl/src/hal/lv_hal_disp.h"
+#include "lvgl/src/hal/lv_hal.h"
 
 void gfx_lvgl_flush(void *_disp_drv, const lv_area_t *area, lv_color_t *color_p) {
-    lv_disp_drv_t *disp_drv = (lv_disp_drv_t*)_disp_drv;
+    lv_disp_t *disp_drv = (lv_disp_t *)_disp_drv;
 
     int idx = mp_obj_get_int(mp_obj_dict_get(disp_drv->user_data, MP_OBJ_NEW_QSTR(MP_QSTR_display_index)));
     LovyanGFX *lvgl_gfx = (LovyanGFX *)&(M5.getDisplay(idx));
@@ -16,12 +16,12 @@ void gfx_lvgl_flush(void *_disp_drv, const lv_area_t *area, lv_color_t *color_p)
 
     lvgl_gfx->startWrite();
     lvgl_gfx->setAddrWindow(area->x1, area->y1, w, h);
-    lvgl_gfx->writePixels((lgfx::rgb565_t *)&color_p->full, w * h);
+    lvgl_gfx->writePixels((lgfx::rgb565_t *)color_p, w * h);
     lvgl_gfx->endWrite();
     lv_disp_flush_ready(disp_drv);
 }
 
-bool gfx_lvgl_touch_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data) {
+bool gfx_lvgl_touch_read(lv_disp_t *indev_drv, lv_indev_data_t *data) {
     M5.update();
 
     if (!M5.Touch.getCount()) {
@@ -38,15 +38,15 @@ bool gfx_lvgl_touch_read(lv_indev_drv_t *indev_drv, lv_indev_data_t *data) {
 
 
 void user_lvgl_flush(void *_disp_drv, const lv_area_t *area, lv_color_t *color_p) {
-    lv_disp_drv_t *disp_drv = (lv_disp_drv_t*)_disp_drv;
+    lv_disp_t *disp_drv = (lv_disp_t*)_disp_drv;
 
     int w = (area->x2 - area->x1 + 1);
     int h = (area->y2 - area->y1 + 1);
 
     user_panel.startWrite();
     user_panel.setAddrWindow(area->x1, area->y1, w, h);
-    user_panel.writePixels((lgfx::rgb565_t *)&color_p->full, w * h);
+    user_panel.writePixels((lgfx::rgb565_t *)color_p, w * h);
     user_panel.endWrite();
-    lv_disp_flush_ready((lv_disp_drv_t *)disp_drv);
+    lv_disp_flush_ready((lv_disp_t *)disp_drv);
 }
 #endif

--- a/m5stack/components/M5Unified/mpy_m5gfx.cpp
+++ b/m5stack/components/M5Unified/mpy_m5gfx.cpp
@@ -19,7 +19,7 @@ extern "C"
 
 #if MICROPY_PY_LVGL
 #include "lvgl/lvgl.h"
-#include "lvgl/src/hal/lv_hal_disp.h"
+#include "lvgl/src/hal/lv_hal.h"
 #include "./../../components/lv_bindings/driver/include/common.h"
 #endif
 

--- a/tests/lvgl/multiple_display.py
+++ b/tests/lvgl/multiple_display.py
@@ -8,35 +8,24 @@ M5.begin()
 # lvgl init
 M5.Lcd.lvgl_init()
 
-# create a display 0 buffer
-disp_buf0 = lv.disp_draw_buf_t()
-buf1_0 = bytearray(M5.getDisplay(0).width() * 10)
-disp_buf0.init(buf1_0, None, len(buf1_0) // lv.color_t.__SIZE__)
+# init function update in lvgl9. ref: https://github.com/lvgl/lvgl/issues/4011 
+# lv_disp_t * disp = lv_disp_create(hor_res, ver_res)
+# lv_disp_set_flush_cb(disp, flush_cb);
+# lv_disp_set_draw_buffers(disp, buf1, buf2, buf_size_in_bytes, mode);
 
-# register display 0 driver
-disp_drv_0 = lv.disp_drv_t()
-disp_drv_0.init()
-disp_drv_0.draw_buf = disp_buf0
-disp_drv_0.flush_cb = M5.Lcd.lvgl_flush
-disp_drv_0.hor_res = M5.getDisplay(0).width()
-disp_drv_0.ver_res = M5.getDisplay(0).height()
-disp_drv_0.user_data = {"display_index": 0}
-disp0 = disp_drv_0.register()
+# create display 0
+disp0 = lv.disp_create(M5.getDisplay(0).width(), M5.getDisplay(0).height())
+disp0.set_flush_cb(M5.Lcd.lvgl_flush)
+buf1_0 = bytearray(M5.getDisplay(0).width() * 10 * lv.color_t.__SIZE__)
+disp0.set_draw_buffers(buf1_0, None, len(buf1_0), lv.DISP_RENDER_MODE.PARTIAL)
+disp0.set_user_data({"display_index": 0})
 
-# create a display 1 buffer
-disp_buf1 = lv.disp_draw_buf_t()
-buf1_1 = bytearray(M5.getDisplay(1).width() * 10)
-disp_buf1.init(buf1_1, None, len(buf1_1) // lv.color_t.__SIZE__)
-
-# register display 1 driver
-disp_drv_1 = lv.disp_drv_t()
-disp_drv_1.init()
-disp_drv_1.draw_buf = disp_buf1
-disp_drv_1.flush_cb = M5.Lcd.lvgl_flush
-disp_drv_1.hor_res = M5.getDisplay(1).width()
-disp_drv_1.ver_res = M5.getDisplay(1).height()
-disp_drv_1.user_data = {"display_index": 1}
-disp1 = disp_drv_1.register()
+# create display 1
+disp1 = lv.disp_create(M5.getDisplay(1).width(), M5.getDisplay(1).height())
+disp1.set_flush_cb(M5.Lcd.lvgl_flush)
+buf1_1 = bytearray(M5.getDisplay(1).width() * 10 * lv.color_t.__SIZE__)
+disp1.set_draw_buffers(buf1_1, None, len(buf1_1), lv.DISP_RENDER_MODE.PARTIAL)
+disp1.set_user_data({"display_index": 1})
 
 # set default display to screen 0
 lv.disp_t.set_default(disp0)
@@ -59,12 +48,14 @@ label1.set_text("LVGL Screen 1")
 lv.scr_load(scr1)
 
 # touch driver init
-indev_drv = lv.indev_drv_t()
-indev_drv.init()
-indev_drv.disp = disp0  # input device assigned to display 0
-indev_drv.type = lv.INDEV_TYPE.POINTER
-indev_drv.read_cb = M5.Lcd.lvgl_read
-indev = indev_drv.register()
+# init function update in lvgl9. ref: https://github.com/lvgl/lvgl/issues/4011 
+# lv_indev_t * indev = lv_indev_create();
+# lv_indev_set_type(indev, LV_INDEV_TYPE_...);
+# lv_indev_set_read_cb(indev, read_cb);
+indev_drv = lv.indev_create()
+indev_drv.set_disp(disp0)  # input device assigned to display 0
+indev_drv.set_type(lv.INDEV_TYPE.POINTER)
+indev_drv.set_read_cb(M5.Lcd.lvgl_read)
 
 # Create an image from the jpg file
 try:


### PR DESCRIPTION
解决之前LVGL=1选项打开时的编译错误。（升级的mpy 1.20 与之前lv_binding 不兼容导致）
- 升级lv_binding，附带升级lvgl到lvgl9
- 将m5unified 接入lvgl9新接口
- mpy中lvgl初始化方式改变。已经在 tests/lvgl/multiple_display.py 中更新。