### PR TITLE
Fix gas resistance reading

### DIFF
--- a/m5stack/libs/driver/bme68x.py
+++ b/m5stack/libs/driver/bme68x.py
@@ -560,7 +560,7 @@ class BME68X:
             if self._variant_id == 0x01:
                 gas_resistance = self.calc_gas_resistance_high(adc_gas_res_high, gas_range_h)
             else:
-                gas_resistance = self.calc_gas_resistance_high(adc_gas_res_low, gas_range_l)
+                gas_resistance = self.calc_gas_resistance_low(adc_gas_res_low, gas_range_l)
 
             self._sensor_data[0].status = status
             self._sensor_data[0].gas_index = gas_index


### PR DESCRIPTION
There is a report in the M5Stack community forum about ENVPro unit not properly reporting gas resistance.

I looked through the code and I think there might be a copy / paste error here.

Note: I do not have an ENVPro unit therefore I cannot test this myself - so I could be wrong here.

Thanks
Felix