### PR TITLE
Adding missing LoRaWANUnit_RUI3

### DIFF
--- a/m5stack/libs/unit/__init__.py
+++ b/m5stack/libs/unit/__init__.py
@@ -77,6 +77,7 @@ _attrs = {
     "LoRaE220433Unit": "lora_e220_433",
     "LoRaE220JPUnit": "lora_e220_jp",
     "LoRaWANUnit": "lorawan",
+    "LoRaWANUnit_RUI3": "lorawan_rui3",
     "MIDIUnit": "midi",
     "MiniOLEDUnit": "minioled",
     "MiniScaleUnit": "miniscale",


### PR DESCRIPTION
As per issue #56 Unable to use new LoRaWANUnits due to missing entry in __init__.py